### PR TITLE
Fixing index 0 vs 1 bug

### DIFF
--- a/get_transformation.py
+++ b/get_transformation.py
@@ -457,7 +457,7 @@ def get_scaling_and_rotation(observation, catalog, wcsprm, scale_guessed, verbos
 def calculate_rms(observation, catalog, wcsprm):
     """Calculate the root mean square deviation of the astrometry fit"""
     #finding pixel scale
-    on_sky = wcsprm.p2s([[0,0],[1,1]], 0)["world"]
+    on_sky = wcsprm.p2s([[0,0],[1,1]], 1)["world"]
     px_scale = np.sqrt((on_sky[0,0]-on_sky[1,0])**2+(on_sky[0,1]-on_sky[1,1])**2)
     px_scale = px_scale*60*60 #in arcsec
     obs_x, obs_y, cat_x, cat_y, distances = find_matches(observation, catalog, wcsprm, threshold=3)

--- a/photometry.py
+++ b/photometry.py
@@ -205,7 +205,7 @@ def main():
         wcsprm = Wcsprm(hdr.tostring().encode('utf-8')) #everything else gave me errors with python 3
 
         #tranlating aperture into pixel:
-        on_sky = wcsprm.p2s([[0,0],[1,1]], 0)["world"]
+        on_sky = wcsprm.p2s([[0,0],[1,1]], 1)["world"]
         px_scale = np.sqrt((on_sky[0,0]-on_sky[1,0])**2+(on_sky[0,1]-on_sky[1,1])**2)
         px_scale = px_scale*60*60 #in arcsec
         aperture = args.aperture / px_scale  #aperture n pixel


### PR DESCRIPTION
There was a bug in the code that caused the new World coordinate system (WCS) to be saved with a (1,1) pixel offset to the output fits file. This was due to starting the indexing for the pixels at (0,0) instead of (1,1) internally in the code. Now the WCS information should be saved correctly so that when rerunning the calibrated file the resulting shift is close to zero and the file should correctly display in other software (tested for ds9). Also updated the plots so that they also start at origin (1,1) instead of (0, 0)